### PR TITLE
Feature: Relational DB structure

### DIFF
--- a/DISCUSSION.md
+++ b/DISCUSSION.md
@@ -12,18 +12,22 @@
 
 ## Backend
 
-- I would like to abstract the database interactions utilizing design
+- ~~I would like to abstract the database interactions utilizing design
   patterns, perhaps the repository pattern, and do so for the various
-  tables in the database schema.
+  tables in the database schema.~~
+
+  Resolved by the move to a normalized data structure.
 
 - I would like to implement API interactions for sorting, pagination,
   and other optimizations that would be necessary for larger data sets.
 
-- I noticed an issue with `jsonb` serialization, and I believe it is a
+- ~~I noticed an issue with `jsonb` serialization, and I believe it is a
   bug with drizzle-kit stringifying the specialties before they get
   stored in the database. I would spend more time researching a solution
   to this fix. Nonetheless, I was able to get around it by anticipating
-  that column would be populated by doubly serialized data.
+  that column would be populated by doubly serialized data.~~
+
+  Resolved by the move to a normalized data structure.
 
 - I don't mind the full stack next.js application, but out of familiarity,
   I'd prefer to aim for an express backend for defining API interactions

--- a/drizzle/0002_melodic_scalphunter.sql
+++ b/drizzle/0002_melodic_scalphunter.sql
@@ -1,0 +1,45 @@
+CREATE TABLE IF NOT EXISTS "advocate_specialties" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"advocate_id" integer NOT NULL,
+	"specialty_id" integer NOT NULL,
+	"created_at" timestamp DEFAULT CURRENT_TIMESTAMP,
+	CONSTRAINT "advocate_specialties_advocate_id_specialty_id_unique" UNIQUE NULLS NOT DISTINCT("advocate_id","specialty_id")
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "specialties" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"title" text NOT NULL,
+	"description" text NOT NULL,
+	"created_at" timestamp DEFAULT CURRENT_TIMESTAMP,
+	CONSTRAINT "specialties_title_unique" UNIQUE("title")
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "advocate_specialties" ADD CONSTRAINT "advocate_specialties_advocate_id_advocates_id_fk" FOREIGN KEY ("advocate_id") REFERENCES "public"."advocates"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "advocate_specialties" ADD CONSTRAINT "advocate_specialties_specialty_id_specialties_id_fk" FOREIGN KEY ("specialty_id") REFERENCES "public"."specialties"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+INSERT INTO specialties (title, description)
+SELECT
+  DISTINCT specialty AS title,
+  '' AS description
+FROM advocates a,
+LATERAL jsonb_array_elements_text((a.specialties #>> '{}')::jsonb) AS specialty;
+--> statement-breakpoint
+INSERT INTO advocate_specialties (advocate_id, specialty_id)
+SELECT
+  a.id AS advocate_id,
+  s.id AS specialty_id
+FROM advocates a
+CROSS JOIN LATERAL jsonb_array_elements_text((a.specialties #>> '{}')::jsonb) AS specialty
+JOIN specialties s ON s.title = specialty;
+--> statement-breakpoint
+ALTER TABLE "advocates" DROP COLUMN IF EXISTS "specialties";
+--> statement-breakpoint

--- a/drizzle/meta/0002_snapshot.json
+++ b/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,189 @@
+{
+  "id": "7aa31987-1ba4-4fd7-b431-f3d17b23a5d1",
+  "prevId": "7bc145c6-7295-4619-b20b-7983f4c3fcdf",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.advocate_specialties": {
+      "name": "advocate_specialties",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "advocate_id": {
+          "name": "advocate_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "specialty_id": {
+          "name": "specialty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "advocate_specialties_advocate_id_advocates_id_fk": {
+          "name": "advocate_specialties_advocate_id_advocates_id_fk",
+          "tableFrom": "advocate_specialties",
+          "tableTo": "advocates",
+          "columnsFrom": [
+            "advocate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "advocate_specialties_specialty_id_specialties_id_fk": {
+          "name": "advocate_specialties_specialty_id_specialties_id_fk",
+          "tableFrom": "advocate_specialties",
+          "tableTo": "specialties",
+          "columnsFrom": [
+            "specialty_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "advocate_specialties_advocate_id_specialty_id_unique": {
+          "name": "advocate_specialties_advocate_id_specialty_id_unique",
+          "nullsNotDistinct": true,
+          "columns": [
+            "advocate_id",
+            "specialty_id"
+          ]
+        }
+      }
+    },
+    "public.advocates": {
+      "name": "advocates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "degree": {
+          "name": "degree",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "years_of_experience": {
+          "name": "years_of_experience",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.specialties": {
+      "name": "specialties",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "specialties_title_unique": {
+          "name": "specialties_title_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "title"
+          ]
+        }
+      }
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1749002123643,
       "tag": "0001_sticky_surge",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1749082321798,
+      "tag": "0002_melodic_scalphunter",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/db/seed.ts
+++ b/scripts/db/seed.ts
@@ -1,21 +1,36 @@
 import db from "@/db";
-import { advocates } from "@/db/schema";
+import { advocates, AdvocateSpecialties, advocateSpecialties, specialties } from "@/db/schema";
 import { advocateData } from "@/db/seed/advocates";
+import { specialtiesData, randomSpecialties } from '@/db/seed/specialties';
 import { keyInYN } from 'readline-sync';
 
 (async function seedAdvocates() {
   try {
-    const clearExisting = keyInYN("Do you want to clear existing advocates before seeding? ");
+    const clearExisting = keyInYN("Do you want to clear existing advocates and other associated data before seeding? ");
     if (clearExisting) {
+      await db.delete(advocateSpecialties);
       await db.delete(advocates);
-      console.log("Cleared existing advocates.");
+      await db.delete(specialties);
+      console.log("Cleared existing advocates and associated data.");
     } else {
       console.log("Skipping clearing existing advocates.");
     }
 
-    const records = await db.insert(advocates).values(advocateData).returning();
+    const specialtiesRecords = await db.insert(specialties).values(specialtiesData).returning();
+    const advocateRecords = await db.insert(advocates).values(advocateData).returning();
+    
+    for (const adv of advocateRecords) {
+      const advocateSpecialtiesEntries: AdvocateSpecialties[] = randomSpecialties(2, specialtiesRecords).map((spec) => ({
+        advocateId: adv.id,
+        specialtyId: spec.id!,
+      }));
 
-    console.log(`Seeded ${records.length} advocates.`);
+      await db.insert(advocateSpecialties).values(advocateSpecialtiesEntries).returning();
+    }
+
+    console.log(`Seeded ${advocateRecords.length} advocates.`);
+    console.log(`Seeded ${specialtiesRecords.length} specialties.`);
+    console.log(`Seeded advocate specialties.`);
     process.exit(0);
   } catch (error) {
     console.error("Error seeding advocates:", error);

--- a/src/app/advocate/[id]/page.tsx
+++ b/src/app/advocate/[id]/page.tsx
@@ -2,22 +2,24 @@
 
 import { Button } from "@/app/components/button";
 import { Chip } from "@/app/components/chip";
-import { PublicAdvocate } from "@/db/schema";
+import { IAdvocate } from "@/app/types/advocate";
+import { ISpecialty } from "@/app/types/specialty";
 import Image from "next/image";
 import Link from "next/link";
 import { useParams, useRouter } from "next/navigation";
 import { ReactNode, useEffect, useState } from "react";
 import { toast } from 'react-toastify';
 
-type AdvocatePropsArray = Array<{
+type AdvocatePropValue = string | Date | number | ISpecialty[] | React.ReactNode;
+type AdvocatePropItem = {
     label: string;
-    col: keyof PublicAdvocate
-}>;
-type AdvocatePropValue = string | string[] | number | Date | null | ReactNode;
+    col: keyof IAdvocate;
+};
+type AdvocatePropsArray = AdvocatePropItem[];
 
 export default function AdvocateView() {
     const { id } = useParams();
-    const [advocate, setAdvocate] = useState<PublicAdvocate | null>(null);
+    const [advocate, setAdvocate] = useState<IAdvocate | null>(null);
     const [loading, setLoading] = useState(true);
     const router = useRouter();
 
@@ -31,7 +33,7 @@ export default function AdvocateView() {
                 return;
             }
 
-            const advocateResponse: PublicAdvocate | null = await response.json();
+            const advocateResponse: IAdvocate | null = await response.json();
             setAdvocate(advocateResponse);
 
             if (advocateResponse === null) {
@@ -96,11 +98,12 @@ export default function AdvocateView() {
                                 label: 'Specialties',
                                 col: 'specialties'
                             }] as AdvocatePropsArray).map((item) => {
+                                
                                 let value: AdvocatePropValue = advocate[item.col];
 
                                 if (item.col === 'specialties') {
-                                    value = (value as string[]).map((str, i) => <div key={i} className="mb-2">
-                                        <Chip text={str} />
+                                    value = (value as ISpecialty[]).map((spc, i) => <div key={i} className="mb-2">
+                                        <Chip text={spc.title} />
                                     </div>);
                                 }
 

--- a/src/app/api/advocate/[id]/route.ts
+++ b/src/app/api/advocate/[id]/route.ts
@@ -1,24 +1,21 @@
-import db from "@/db";
-import { advocates } from "@/db/schema";
-import { eq } from "drizzle-orm";
+import { AdvocateRepository } from "@/db/repositories/advocate/advocate-repository";
 import { NextRequest } from "next/server";
+
+const advocateRepo = new AdvocateRepository();;
 
 export async function GET(
   _: NextRequest,
   { params }: { params: { id: string } }
 ) {
   if (!params.id) {
-    throw new ReferenceError('The route param :id is required.')
+    throw new ReferenceError("The route param :id is required.");
   }
 
   if (isNaN(Number(params.id))) {
-    throw new Error('The given id must be a number.')
+    throw new Error("The given id must be a number.");
   }
 
-  const [advocate] = await db
-    .select()
-    .from(advocates)
-    .where(eq(advocates.id, Number(params.id)));
+  const advocate = await advocateRepo.findByIdAsync(Number(params.id));
 
   if (!advocate) {
     return Response.json(null);

--- a/src/app/api/advocates/route.ts
+++ b/src/app/api/advocates/route.ts
@@ -1,51 +1,17 @@
 import { NextRequest } from "next/server";
-import db from "../../../db";
-import { advocates, PublicAdvocate } from "../../../db/schema";
-import { ilike, or, sql } from "drizzle-orm";
+import { AdvocateRepository } from "@/db/repositories/advocate/advocate-repository";
+
+const advocateRepo = new AdvocateRepository();
 
 export async function GET(req: NextRequest) {
   const { searchParams } = new URL(req.url);
   const searchTerm = searchParams.get("searchTerm");
-  let data: PublicAdvocate[] = [];
 
   if (searchTerm) {
-    data = await db
-      .select()
-      .from(advocates)
-      .where(
-        or(
-          ...[
-            advocates.firstName,
-            advocates.lastName,
-            advocates.city,
-            advocates.degree,
-            advocates.phoneNumber,
-          ].map((col) => ilike(col, `%${searchTerm}%`)),
-          // There appears to be a bug in drizzle-kit where
-          // jsonb values are being doubly serialized, as is
-          // the case with advocates.specialties, the values
-          // appear like this.
-          //
-          // "[\"String 1\", \"String 2\"]"
-          // 
-          // In order to search in this doubly serialized array,
-          // I need to deserialize and then search.
-          sql`
-            EXISTS (
-             SELECT 1 FROM jsonb_array_elements_text((${
-               advocates.specialties
-             } #>> '{}')::jsonb) AS s
-             WHERE s ILIKE ${`%${searchTerm}%`}
-           )
-          `,
-          sql`CAST(${
-            advocates.yearsOfExperience
-          } AS TEXT) ILIKE ${`%${searchTerm}%`}`
-        )
-      );
-  } else {
-    data = await db.select().from(advocates);
+    const data = await advocateRepo.textSearchAsync(searchTerm);
+    return Response.json({ data });
   }
 
+  const data = await advocateRepo.findAllAsync();
   return Response.json({ data });
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,15 +1,15 @@
 "use client";
 
-import { SelectAdvocate } from "@/db/schema";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { toast } from 'react-toastify';
 import { useDebounce } from "use-debounce";
 import { Chip } from "./components/chip";
 import { Button } from "./components/button";
+import { IAdvocate } from "./types/advocate";
 
 export default function Home() {
-  const [advocates, setAdvocates] = useState<SelectAdvocate[]>([]);
+  const [advocates, setAdvocates] = useState<IAdvocate[]>([]);
   const [searchTerm, setSearchTerm] = useState("");
   const [initialized, setInitialized] = useState(false);
   const [loading, setLoading] = useState(true);
@@ -35,7 +35,7 @@ export default function Home() {
           return;
         }
         const jsonResponse = await response.json();
-        setAdvocates(jsonResponse.data as SelectAdvocate[]);
+        setAdvocates(jsonResponse.data as IAdvocate[]);
         setInitialized(true);
       } catch (error) {
         console.error("Failed to fetch advocates:", error);
@@ -59,19 +59,18 @@ export default function Home() {
   return (
     <>
       <div className="m-24">
-        {!loading && initialized && (
-          <div className="mb-10 flex flex-row align-items-center">
-            <div className="mt-5">
-              <span className="font-bold text-2xl mr-8 m">Search</span>
-              <input
-                type="text"
-                onChange={onSearchTermChange} value={searchTerm}
-                className="rounded-2xl py-1 px-2 border-[1.5px] focus:border-[1.5px] outline-none focus:outline-none focus:ring-0 w-[30vw]"
-                placeholder="Enter search term" />
-                <Button onClick={onResetSearchClick}>Reset Search</Button>
-            </div>
+        <div className="mb-10 flex flex-row align-items-center">
+          <div className="mt-5">
+            <span className="font-bold text-2xl mr-8 m">Search</span>
+            <input
+              type="text"
+              onChange={onSearchTermChange} value={searchTerm}
+              className="rounded-2xl py-1 px-2 border-[1.5px] focus:border-[1.5px] outline-none focus:outline-none focus:ring-0 w-[30vw]"
+              placeholder="Enter search term"
+              disabled={!initialized} />
+            <Button onClick={onResetSearchClick}>Reset Search</Button>
           </div>
-        )}
+        </div>
         {advocates.length > 0 && (
           <table className="w-full border-[1px] border-[var(--solace-green)]">
             <thead>
@@ -91,7 +90,7 @@ export default function Home() {
                     <td className="w-32 text-center">{advocate.degree}</td>
                     <td>
                       {advocate.specialties.map((s, i) => (
-                        <Chip key={i} text={s} />
+                        <Chip key={i} text={s.title} />
                       ))}
                     </td>
                     <td>{advocate.yearsOfExperience}</td>

--- a/src/app/types/advocate.ts
+++ b/src/app/types/advocate.ts
@@ -1,0 +1,12 @@
+import { IBaseType } from "./base";
+import { ISpecialty } from "./specialty";
+
+export interface IAdvocate extends IBaseType {
+    firstName: string;
+    lastName: string;
+    city: string;
+    degree: string;
+    yearsOfExperience: number;
+    phoneNumber: string;
+    specialties: ISpecialty[];
+};

--- a/src/app/types/base.ts
+++ b/src/app/types/base.ts
@@ -1,0 +1,4 @@
+export interface IBaseType {
+    id: number | undefined;
+    createdAt: Date | null | undefined;
+};

--- a/src/app/types/specialty.ts
+++ b/src/app/types/specialty.ts
@@ -1,0 +1,6 @@
+import { IBaseType } from "./base";
+
+export interface ISpecialty extends IBaseType {
+    title: string;
+    description: string;
+};

--- a/src/db/repositories/advocate/advocate-repository.ts
+++ b/src/db/repositories/advocate/advocate-repository.ts
@@ -1,0 +1,117 @@
+import { IAdvocate } from "@/app/types/advocate";
+import db from "@/db";
+import {
+  advocates,
+  AdvocateSpecialties,
+  advocateSpecialties,
+  SelectAdvocate,
+  Specialties,
+  specialties,
+} from "@/db/schema";
+import { eq, ilike, or, sql } from "drizzle-orm";
+import { IRepository } from "@/db/repositories/repository";
+
+type AmalgamatedType = {
+  advocates: SelectAdvocate;
+  advocate_specialties: AdvocateSpecialties | null;
+  specialties: Specialties | null;
+};
+
+export class AdvocateRepository implements IRepository<IAdvocate> {
+  async findAllAsync(): Promise<IAdvocate[]> {
+    const data = await db
+      .select()
+      .from(advocates)
+      .leftJoin(
+        advocateSpecialties,
+        eq(advocateSpecialties.advocateId, advocates.id)
+      )
+      .leftJoin(
+        specialties,
+        eq(advocateSpecialties.specialtyId, specialties.id)
+      );
+
+    return this.amalgamateJoinedRowsToIAdvocate(data);
+  }
+
+  async findByIdAsync(id: number): Promise<IAdvocate> {
+    const data = await db
+      .select()
+      .from(advocates)
+      .innerJoin(
+        advocateSpecialties,
+        eq(advocateSpecialties.advocateId, advocates.id)
+      )
+      .innerJoin(
+        specialties,
+        eq(specialties.id, advocateSpecialties.specialtyId)
+      )
+      .where(eq(advocates.id, id));
+
+    const [advocate] = this.amalgamateJoinedRowsToIAdvocate(data)
+
+    return advocate;
+  }
+
+  async textSearchAsync(term: string): Promise<IAdvocate[]> {
+    if (term) {
+      const data = await db
+        .select()
+        .from(advocates)
+        .innerJoin(
+          advocateSpecialties,
+          eq(advocateSpecialties.advocateId, advocates.id)
+        )
+        .innerJoin(
+          specialties,
+          eq(advocateSpecialties.specialtyId, specialties.id)
+        )
+        .where(
+          or(
+            ...[
+              advocates.firstName,
+              advocates.lastName,
+              advocates.city,
+              advocates.degree,
+              advocates.phoneNumber,
+            ].map((col) => ilike(col, `%${term}%`)),
+            ilike(specialties.title, `%${term}%`),
+            ilike(specialties.description, `%${term}%`),
+            sql`CAST(${
+              advocates.yearsOfExperience
+            } AS TEXT) ILIKE ${`%${term}%`}`
+          )
+        );
+      return this.amalgamateJoinedRowsToIAdvocate(data);
+    }
+    return [];
+  }
+
+  private amalgamateJoinedRowsToIAdvocate(
+    rows: AmalgamatedType[]
+  ): IAdvocate[] {
+    const advocateMap = new Map<number, IAdvocate>();
+
+    for (const row of rows) {
+      const advocateId = row.advocates.id;
+
+      if (!advocateMap.has(advocateId)) {
+        advocateMap.set(advocateId, {
+          ...row.advocates,
+          specialties: [],
+        });
+      }
+
+      if (row.specialties && row.advocate_specialties) {
+        advocateMap.get(advocateId)?.specialties.push({
+          createdAt: row.advocate_specialties.createdAt,
+          description: row.specialties.description,
+          title: row.specialties.title,
+          id: row.advocate_specialties.id,
+        });
+      }
+    }
+
+    return Array.from(advocateMap.values());
+  }
+}

--- a/src/db/repositories/repository.ts
+++ b/src/db/repositories/repository.ts
@@ -1,0 +1,5 @@
+export interface IRepository<T> {
+    findAllAsync(): Promise<T[]>;
+    findByIdAsync(id: number): Promise<T>;
+    textSearchAsync(term: string): Promise<T[]>;
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -3,9 +3,9 @@ import {
   pgTable,
   integer,
   text,
-  jsonb,
   serial,
   timestamp,
+  unique,
 } from "drizzle-orm/pg-core";
 
 export const advocates = pgTable("advocates", {
@@ -14,13 +14,31 @@ export const advocates = pgTable("advocates", {
   lastName: text("last_name").notNull(),
   city: text("city").notNull(),
   degree: text("degree").notNull(),
-  specialties: jsonb("specialties").$type<string[]>().default([]).notNull(),
   yearsOfExperience: integer("years_of_experience").notNull(),
   phoneNumber: text("phone_number").notNull(),
   createdAt: timestamp("created_at").default(sql`CURRENT_TIMESTAMP`),
 });
 
+export const specialties = pgTable("specialties", {
+  id: serial("id").primaryKey(),
+  title: text("title").notNull().unique(),
+  description: text("description").notNull(),
+  createdAt: timestamp("created_at").default(sql`CURRENT_TIMESTAMP`)
+});
+
+export const advocateSpecialties = pgTable("advocate_specialties", {
+  id: serial("id").primaryKey(),
+  advocateId: integer("advocate_id").notNull().references(() => advocates.id),
+  specialtyId: integer("specialty_id").notNull().references(() => specialties.id),
+  createdAt: timestamp("created_at").default(sql`CURRENT_TIMESTAMP`)
+}, (table) => ({
+  uniqueAdvocateAndSpecialty: unique().on(table.advocateId, table.specialtyId).nullsNotDistinct()
+}));
+
 export type SelectAdvocate = typeof advocates.$inferSelect;
 export type InsertAdvocate = typeof advocates.$inferInsert;
 export type GeneratedAdvocate = Omit<SelectAdvocate, 'id' | 'createdAt'>
 export type PublicAdvocate = Omit<SelectAdvocate, 'id'>;
+
+export type Specialties = typeof specialties.$inferInsert;
+export type AdvocateSpecialties = typeof advocateSpecialties.$inferInsert;

--- a/src/db/seed/advocates.ts
+++ b/src/db/seed/advocates.ts
@@ -1,5 +1,4 @@
 import { generateRandomNumber } from "@/app/helpers/random-number";
-import { randomSpecialties } from "./specialties";
 import { GeneratedAdvocate } from "../schema";
 
 export const advocateData: GeneratedAdvocate[] = Array.from({ length: 15 }, generateRandomAdvocate);
@@ -10,7 +9,6 @@ function generateRandomAdvocate(): GeneratedAdvocate {
     lastName: generateRandomLastName(),
     city: generateRandomCity(),
     degree: generateRandomDegree(),
-    specialties: randomSpecialties(2),
     yearsOfExperience: generateRandomNumber(1, 20),
     phoneNumber: generateRandomPhoneNumber(),
   };

--- a/src/db/seed/specialties.ts
+++ b/src/db/seed/specialties.ts
@@ -1,6 +1,7 @@
 import { generateRandomNumber } from "@/app/helpers/random-number";
+import type { Specialties } from "../schema";
 
-export const specialties = [
+export const specialtiesData: Specialties[] = [
   "Bipolar",
   "LGBTQ",
   "Medication/Prescribing",
@@ -27,10 +28,13 @@ export const specialties = [
   "Schizophrenia and psychotic disorders",
   "Learning disorders",
   "Domestic abuse",
-];
+].map((sp) => ({
+  description: '',
+  title: sp
+}));
 
-export function randomSpecialties(length: number): string[] {
-  const distinctSpecialties = new Set<string>();
+export function randomSpecialties(length: number, specialties: Specialties[]): Specialties[] {
+  const distinctSpecialties = new Set<Specialties>();
 
   while (distinctSpecialties.size < length) {
     const randomIndex = generateRandomNumber(0, specialties.length - 1);


### PR DESCRIPTION
Moving the advocates and specialties to normalized data structure. I got a little tired of dealing with the casting of jsonb due to the limitations of drizzle-kit, so I decided to opt for a normalized data structure.

It comes at a cost of convenience, but I think the normalized data structure will perform better for querying larger data sets. Also, the new data structure will support better indexing across the tables, as that must be a consideration when the data set grows.

Due to the relational data modeling, I opted for interfaces to represent that data when passing it between the UI and API layers. It's a slight maintenance overhead, but I think it makes dealing with the data easier than trying to infer the data types from drizzle.

Despite initially not committing to it in my DISCUSSION.md comments, I felt it necessary to implement the repository pattern to facilitate the extraction of records in a clean and reusable way. I defined a base interface for the repository to follow, which could be expanded upon with different CRUD methods.