### PR TITLE
Feature: Unify seeding approaches

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "db:push": "drizzle-kit push",
     "db:migrate": "drizzle-kit migrate",
     "db:seed": "tsx --env-file=.env ./scripts/db/seed.ts",
-    "db:initialize": "npm run db:generate && npm run db:migrate && npm run db:seed"
+    "db:initialize": "npm run db:generate && npm run db:migrate && npm run db:seed",
+    "db:initialize:no-seed": "npm run db:generate && npm run db:migrate"
   },
   "dependencies": {
     "drizzle-orm": "^0.32.1",

--- a/scripts/db/seed.ts
+++ b/scripts/db/seed.ts
@@ -1,36 +1,17 @@
-import db from "@/db";
-import { advocates, AdvocateSpecialties, advocateSpecialties, specialties } from "@/db/schema";
-import { advocateData } from "@/db/seed/advocates";
-import { specialtiesData, randomSpecialties } from '@/db/seed/specialties';
+import { reset, seeder } from '@/db/seed/seeder';
 import { keyInYN } from 'readline-sync';
 
 (async function seedAdvocates() {
   try {
     const clearExisting = keyInYN("Do you want to clear existing advocates and other associated data before seeding? ");
     if (clearExisting) {
-      await db.delete(advocateSpecialties);
-      await db.delete(advocates);
-      await db.delete(specialties);
+      await reset();
       console.log("Cleared existing advocates and associated data.");
     } else {
       console.log("Skipping clearing existing advocates.");
     }
 
-    const specialtiesRecords = await db.insert(specialties).values(specialtiesData).returning();
-    const advocateRecords = await db.insert(advocates).values(advocateData).returning();
-    
-    for (const adv of advocateRecords) {
-      const advocateSpecialtiesEntries: AdvocateSpecialties[] = randomSpecialties(2, specialtiesRecords).map((spec) => ({
-        advocateId: adv.id,
-        specialtyId: spec.id!,
-      }));
-
-      await db.insert(advocateSpecialties).values(advocateSpecialtiesEntries).returning();
-    }
-
-    console.log(`Seeded ${advocateRecords.length} advocates.`);
-    console.log(`Seeded ${specialtiesRecords.length} specialties.`);
-    console.log(`Seeded advocate specialties.`);
+    await seeder();
     process.exit(0);
   } catch (error) {
     console.error("Error seeding advocates:", error);

--- a/src/app/api/seed/route.ts
+++ b/src/app/api/seed/route.ts
@@ -1,9 +1,21 @@
-import db from "../../../db";
-import { advocates } from "../../../db/schema";
-import { advocateData } from "../../../db/seed/advocates";
+import { AdvocateRepository } from "@/db/repositories/advocate/advocate-repository";
+import { seeder, reset } from "@/db/seed/seeder";
+
+const advocateRepo = new AdvocateRepository();
 
 export async function POST() {
-  const records = await db.insert(advocates).values(advocateData).returning();
+  try {
+    await seeder();
+    const advocates = await advocateRepo.findAllAsync();
 
-  return Response.json({ advocates: records });
+    return Response.json({ advocates });
+  } catch (e) {
+    console.log(e);
+    return Response.error();
+  }
+}
+
+export async function DELETE() {
+  await reset();
+  return Response.json({ ok: true });
 }

--- a/src/db/seed/seeder.ts
+++ b/src/db/seed/seeder.ts
@@ -1,0 +1,45 @@
+import db from "..";
+import {
+  specialties,
+  advocates,
+  AdvocateSpecialties,
+  advocateSpecialties,
+} from "../schema";
+import { advocateData } from "./advocates";
+import { specialtiesData, randomSpecialties } from "./specialties";
+
+export async function seeder() {
+  const specialtiesRecords = await db
+    .insert(specialties)
+    .values(specialtiesData)
+    .returning();
+  const advocateRecords = await db
+    .insert(advocates)
+    .values(advocateData)
+    .returning();
+
+  for (const adv of advocateRecords) {
+    const advocateSpecialtiesEntries: AdvocateSpecialties[] = randomSpecialties(
+      2,
+      specialtiesRecords
+    ).map((spec) => ({
+      advocateId: adv.id,
+      specialtyId: spec.id!,
+    }));
+
+    await db
+      .insert(advocateSpecialties)
+      .values(advocateSpecialtiesEntries)
+      .returning();
+  }
+
+  console.log(`Seeded ${advocateRecords.length} advocates.`);
+  console.log(`Seeded ${specialtiesRecords.length} specialties.`);
+  console.log(`Seeded advocate specialties.`);
+}
+
+export async function reset() {
+  await db.delete(advocateSpecialties);
+  await db.delete(advocates);
+  await db.delete(specialties);
+}


### PR DESCRIPTION
Moved seeder to consolidated approach between api and script.

Implemented the unified function in the API route.

Added delete capabilities to API — most definitely not a real world practice, but simply here for the sake of demonstration. Absolutely would not, and must not have seeding or delete capabilities anywhere near a public facing API.